### PR TITLE
Add crypto appdata file.

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries( ${PROGNAME}
 
 if(UNIX AND NOT APPLE)
 	install( FILES qdigidoc-crypto.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications )
+	install( FILES qdigidoc-cypto.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/appdata )	
 	install( FILES qdigidoc-crypto.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages )
 	foreach(RES 16 22 32 48 128)
 		install(

--- a/crypto/qdigidoc-crypto.desktop
+++ b/crypto/qdigidoc-crypto.desktop
@@ -9,5 +9,8 @@ Name=DigiDoc Crypto
 Name[et]=DigiDoc krüpto
 Name[ru]=DigiDoc Crypto
 
+Keywords=Crypto;Digital;Signature;
+Keywords[et_EE]=Krüpto;Digitaalne;Allkiri;
+
 Categories=Qt;Office;
 MimeType=application/x-cdoc;

--- a/crypto/qdigidoc-cypto.appdata.xml
+++ b/crypto/qdigidoc-cypto.appdata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2015 Mihkel Vain <mihkel@fedoraproject.org> -->
+<component type="desktop">
+  <metadata_license>CC0-1.0</metadata_license>
+  <id>qdigidoc-crypto.desktop</id>
+  <metadata>
+    <value key="X-Merge-With-Parent">qdigidoc-client.desktop</value>
+  </metadata>
+</component>


### PR DESCRIPTION
This hides crypto from software center applications.
Also add English and Estonian keywords to desktop file.

Signed-off-by: Mihkel Vain <mihkel@fedoraproject.org>