### PR TITLE
File open and save with progress in background thread

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -870,6 +870,7 @@ void Application::waitForTSL( const QString &file )
 		return;
 
 	QProgressDialog p( tr("Loading TSL lists"), QString(), 0, 0, qApp->activeWindow() );
+	p.setWindowTitle( tr("DigiDoc3 client") );
 	p.setWindowFlags( (p.windowFlags() | Qt::CustomizeWindowHint) & ~Qt::WindowCloseButtonHint );
 	if( QProgressBar *bar = p.findChild<QProgressBar*>() )
 		bar->setTextVisible( false );

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -21,7 +21,12 @@
 
 #include "ui_MainWindow.h"
 
+#include "DigiDoc.h"
+
 #include <QtCore/QStringList>
+#include <QtWidgets/QProgressDialog>
+
+#include <memory>
 
 class DigiDoc;
 class QPrinter;
@@ -36,17 +41,25 @@ public:
 	void closeDoc();
 
 private Q_SLOTS:
+	void activateProgressDlg( const QString &fileName, const QString &title, bool cancellable );
+	void added( int taskId, bool success );
 	void buttonClicked( int button );
+	void cancelOperation();
 	void changeCard( QAction *a );
 	void changeLang( QAction *a );
+	void closeProgress();
 	void enableSign();
 	void messageClicked( const QString &link );
 	void on_introCheck_stateChanged( int state );
 	void on_languages_activated( int index );
 	void open( const QStringList &params );
+	void opened( int taskId, bool success );
 	void parseLink( const QString &link );
 	void printSheet( QPrinter * );
+	void saved( int taskId, bool success );
+	void setProgress( int value );
 	void showCardStatus();
+	void verifyExternally();
 	void viewSignaturesRemove( unsigned int num );
 
 private:
@@ -78,12 +91,13 @@ private:
 		ViewSaveFiles
 	};
 	bool addFile( const QString &file );
+	void enableSign( int warning );
 	bool event( QEvent *e );
 	void loadRoles();
 	void retranslate();
-	void save();
+	void save( DigiDoc::SaveAction action );
 	QString selectFile( const QString &filename, bool fixedExt );
-	void setCurrentPage( Pages page );
+	void setCurrentPage( Pages page, QList<DigiDocSignature::SignatureStatus> *validatedSignatures = nullptr );
 	void showWarning( const QString &text );
 
 	QActionGroup *cardsGroup;
@@ -93,4 +107,9 @@ private:
 	int prevpage;
 	QLabel *message;
 	bool warnOnUnsignedDocCancel;
+	std::shared_ptr<QProgressDialog> progressDlg;
+
+Q_SIGNALS:
+	void progressFinished();
+
 };

--- a/client/SignatureDialog.cpp
+++ b/client/SignatureDialog.cpp
@@ -37,7 +37,7 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QPushButton>
 
-SignatureWidget::SignatureWidget( const DigiDocSignature &signature, unsigned int signnum, QWidget *parent )
+SignatureWidget::SignatureWidget( const DigiDocSignature &signature, DigiDocSignature::SignatureStatus status, unsigned int signnum, QWidget *parent )
 :	QLabel( parent )
 ,	num( signnum )
 ,	s( signature )
@@ -93,7 +93,7 @@ SignatureWidget::SignatureWidget( const DigiDocSignature &signature, unsigned in
 	sa << " " << tr("Signature is") << " ";
 	sc << "<table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\"><tr>";
 	sc << "<td>" << tr("Signature is") << " ";
-	switch( s.validate() )
+	switch( status )
 	{
 	case DigiDocSignature::Valid:
 		sa << tr("valid");

--- a/client/SignatureDialog.h
+++ b/client/SignatureDialog.h
@@ -33,7 +33,7 @@ class SignatureWidget: public QLabel
 	Q_OBJECT
 
 public:
-	explicit SignatureWidget( const DigiDocSignature &s, unsigned int signnum, QWidget *parent = 0 );
+    explicit SignatureWidget( const DigiDocSignature &s, DigiDocSignature::SignatureStatus status, unsigned int signnum, QWidget *parent = 0 );
 
 Q_SIGNALS:
 	void removeSignature( unsigned int num );

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -159,6 +159,18 @@
         <translation>You have not granted IP-based access. Check the settings of your server access certificate.</translation>
     </message>
     <message>
+        <source>Opening container</source>
+        <translation>Opening container</translation>
+    </message>
+    <message>
+        <source>Saving container</source>
+        <translation>Saving container</translation>
+    </message>
+    <message>
+        <source>Adding a file to container</source>
+        <translation>Adding a file to container</translation>
+    </message>
+    <message>
         <source>Failed to get signatures</source>
         <translation type="unfinished"></translation>
     </message>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -159,6 +159,18 @@
         <translation>Puudub IP-põhine ligipääs, kontrolli juurdepääsutõendi seadeid.</translation>
     </message>
     <message>
+      <source>Opening container</source>
+      <translation>Ümbriku avamine</translation>
+    </message>
+    <message>
+      <source>Saving container</source>
+      <translation>Ümbriku salvestamine</translation>
+    </message>
+    <message>
+      <source>Adding a file to container</source>
+      <translation>Faili lisamine ümbrikusse</translation>
+    </message>
+    <message>
         <source>Failed to get signatures</source>
         <translation type="unfinished"></translation>
     </message>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -160,6 +160,18 @@
         <translation>Отсутствует IP-основанный доступ. Проверьте настройки справки доступа.</translation>
     </message>
     <message>
+      <source>Opening container</source>
+      <translation>Открывается конверт</translation>
+    </message>
+    <message>
+      <source>Saving container</source>
+      <translation>Coxраняется конверт</translation>
+    </message>
+    <message>
+      <source>Adding a file to container</source>
+      <translation>Дoбавляется файл в конверт</translation>
+    </message>
+    <message>
         <source>Failed to get signatures</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
IB-4561: Perform file open and save operations in background worker thread (task) if
size of a container is over the hard-coded threshold (100MB):
- Show progress bar during the operation
- Open can be interrupted after container is loaded and before the validation
  of each signature of the container.
- Save cannot be interrupted; save is performed
  - in case of normal save
  - after removing signature
  - when unsigned container is closed
  - after signing

Some performance improvements are made in signature validation: signature
is not checked multiple times when container is opened.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>